### PR TITLE
fix: support extendable placeholder without extending it

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -106,7 +106,7 @@ function partial(func, ...boundArgs) {
         const newArgs = boundArgs
             .map(arg => {
                 let calculatedArg = arg;
-                if (isExtendableSelector(arg) && isNotNullObject(args[argIndex])) {
+                if (isExtendableSelector(arg)) {
                     calculatedArg = {...arg.selectorObj, ...args[argIndex++]};
                 } else if (isPlaceholder(arg)) {
                     calculatedArg = args[argIndex++];

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -107,6 +107,16 @@ Array [
 ]
 `;
 
+exports[`redux selector action reduxSelectorActionMiddleware should inject object to placeholders without extending the object 1`] = `
+Array [
+  Array [
+    Object {
+      "prop1": "prop1Value",
+    },
+  ],
+]
+`;
+
 exports[`redux selector action reduxSelectorActionMiddleware should inject selectors output and non-function values to the given action creator 1`] = `
 Array [
   Array [

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -145,5 +145,12 @@ describe('redux selector action', () => {
             expect(dispatch).toHaveBeenCalled();
             expect(actionCreator.mock.calls).toMatchSnapshot();
         });
+
+        it('should inject object to placeholders without extending the object', () => {
+            selectorAction.meta.selectors.push(getPlaceholder({prop1: () => 'prop1Value'}));
+            handleAction(selectorAction);
+            expect(dispatch).toHaveBeenCalled();
+            expect(actionCreator.mock.calls).toMatchSnapshot();
+        });
     });
 });


### PR DESCRIPTION
Today if I create an object placeholder this way:
getPlaceholder({a: 1})
I can pass another object as an arg to extend it {b: 2}
But I can't use it without extending it.

example:
```
const action = createSelectorAction(
    getPlaceholder({a: 1}),
    ({a, b = 2}) => {}
);

action({b: 2}); // supported
action(); // not supported
```

With this fix:
```
action(); // supported
```